### PR TITLE
Allow STATIFY_PATH and CONFIG_PATH to be overridden by environment

### DIFF
--- a/statify/config.py
+++ b/statify/config.py
@@ -3,5 +3,8 @@ from pathlib import Path
 
 VERSION = '1.0'
 
-STATIFY_PATH = Path(os.environ.get('STATIFY_DATA', Path.home() / '.data' / 'statify'))
-CONFIG_PATH  = Path(os.environ.get('STATIFY_CONFIG', Path.home() / '.config' / 'statify.yaml'))
+STATIFY_PATH = Path(os.environ.get('STATIFY_DATA', 
+                    Path.home() / '.data' / 'statify'))
+
+CONFIG_PATH = Path(os.environ.get('STATIFY_CONFIG',
+                    Path.home() / '.config' / 'statify.yaml'))

--- a/statify/config.py
+++ b/statify/config.py
@@ -1,7 +1,7 @@
+import os
 from pathlib import Path
-
 
 VERSION = '1.0'
 
-STATIFY_PATH = Path.home() / '.data' / 'statify'
-CONFIG_PATH = Path.home() / '.config' / 'statify.yaml'
+STATIFY_PATH = Path(os.environ.get('STATIFY_DATA', Path.home() / '.data' / 'statify'))
+CONFIG_PATH  = Path(os.environ.get('STATIFY_CONFIG', Path.home() / '.config' / 'statify.yaml'))

--- a/statify/config.py
+++ b/statify/config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 VERSION = '1.0'
 
-STATIFY_PATH = Path(os.environ.get('STATIFY_DATA', 
+STATIFY_PATH = Path(os.environ.get('STATIFY_DATA',
                     Path.home() / '.data' / 'statify'))
 
 CONFIG_PATH = Path(os.environ.get('STATIFY_CONFIG',


### PR DESCRIPTION
### Context

Thought I would add convenience environment variables to the config as I found forcing the use of `~/.data/statify` and `~/.config/statify.yaml` can be a little restricting.

### Changes
* STATIFY_PATH can now be set as an environment variable `STATIFY_DATA`
* CONFIG_PATH can now be set as an environment variable `STATIFY_CONFIG`